### PR TITLE
3 changes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,9 @@
   in the factory for demo and blob storage, the demo storage now wraps the
   blob storage instead of the other way around as it was previously.
 
+- Made sure the ``repoze.zodbconn.connector`` middleware calls the sub
+  application before returning an iterator.
+
 0.13 (2011-06-04)
 -----------------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,12 @@
 - Made sure the ``repoze.zodbconn.connector`` middleware calls the sub
   application before returning an iterator.
 
+- Reverted the change from 0.12 to eagerly open the database at startup time.
+  Changed to lazily opening the database but the accessor for the database is
+  now guarded by a lock in order to prevent the race condition being targed by
+  the change from 0.12.
+
+
 0.13 (2011-06-04)
 -----------------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,13 @@
 ``repoze.zodbconn`` Changelog
 =============================
 
+0.14 (Unreleased)
+-----------------
+
+- Made compatible with ZODB 3.10.3.  The only change to non-testing code is
+  in the factory for demo and blob storage, the demo storage now wraps the
+  blob storage instead of the other way around as it was previously.
+
 0.13 (2011-06-04)
 -----------------
 

--- a/repoze/zodbconn/resolvers.py
+++ b/repoze/zodbconn/resolvers.py
@@ -85,7 +85,7 @@ class MappingStorageURIResolver(Resolver):
             storage = MappingStorage(*args)
             return DB(storage, **dbkw)
         return key, args, kw, factory
-        
+
 class FileStorageURIResolver(Resolver):
     _int_args = ('create', 'read_only', 'demostorage', 'connection_cache_size',
                  'connection_pool_size')
@@ -126,10 +126,10 @@ class FileStorageURIResolver(Resolver):
         if demostorage and blobstorage_dir:
             def factory():
                 filestorage = FileStorage(*args, **kw)
-                demostorage = DemoStorage(base=filestorage)
-                blobstorage = BlobStorage(blobstorage_dir, demostorage,
+                blobstorage = BlobStorage(blobstorage_dir, filestorage,
                                           layout=blobstorage_layout)
-                return DB(blobstorage, **dbkw)
+                demostorage = DemoStorage(base=blobstorage)
+                return DB(demostorage, **dbkw)
         elif blobstorage_dir:
             def factory():
                 filestorage = FileStorage(*args, **kw)

--- a/repoze/zodbconn/tests/test_cachecleanup.py
+++ b/repoze/zodbconn/tests/test_cachecleanup.py
@@ -26,6 +26,13 @@ class TestCacheCleanup(unittest.TestCase):
     def tearDown(self):
         self.db.close()
 
+    def assertConnectionOpened(self, conn): #pragma NO COVERAGE
+        # Attribute name changes across ZODB versions
+        opened = getattr(conn, '_opened', None)
+        if opened is None:
+            opened = conn.opened
+        self.assertNotEqual(opened, None)
+
     def test_cleanup(self):
         from repoze.zodbconn.cachecleanup import CacheCleanup
         connection_key = 'connection'
@@ -34,7 +41,7 @@ class TestCacheCleanup(unittest.TestCase):
             conn = environ[connection_key]
             root = conn.root()
             root['keepme']['extra'].values()  # load objects
-            self.assertNotEqual(conn._opened, None)
+            self.assertConnectionOpened(conn)
             self.assertEqual(root._p_changed, False)
             self.assertEqual(root['keepme']._p_changed, False)
             self.assertEqual(root['keepme']['extra']._p_changed, False)


### PR DESCRIPTION
I've made repoze.zodbconn compatible with the latest ZODB3 release.  I've also fixed a couple of issues I found during testing.

The change from 0.13 which added streaming support, failed to make sure the subapplication was called before returning.  This can cause other middleware to fail.  repoze.retry, for instance, expects that start_response has been called before the app_iter has been returned.  This has been fixed.

The change from 0.12 which added eager loading of the database in the PersistentApplicationFinder can, under some circumstances, cause the database to be created twice if being used with the connector middleware.  Karl for instance, uses the connector middleware because it uses repoze.who, but also passes a zodb_uri (instead of None) to the PersistentApplicationFinder so that console scripts can still work, when there is no middleware.  To fix this, I changed the eager loading to a lazy loading scheme and used a lock to guard against the race condition which was the impetus for the 0.12 change.

I'm happy to merge these changes myself, but I decided to do a fork/pull request so I could at least get Chris M or Tres to eyeball the changes.
